### PR TITLE
Automatically fill up UOM table and Item field customizations

### DIFF
--- a/ganapathy_pavers/custom/js/item.js
+++ b/ganapathy_pavers/custom/js/item.js
@@ -48,3 +48,52 @@ function bundle(frm,cdt,cdn) {
     var bundle_per_sqr_ft = data.pavers_per_bundle/data.pavers_per_sqft
     frm.set_value("bundle_per_sqr_ft" , bundle_per_sqr_ft.toFixed(2))
 }
+
+
+frappe.ui.form.on("Item",
+{ item_group: function(frm) {
+    uom(frm);
+    },
+ pavers_per_sqft: function(frm) {
+    uom(frm);
+    },
+ pavers_per_bundle: function(frm) {
+    uom(frm);
+    },
+stock_uom: function(frm) {
+    uom(frm);
+    }
+}
+);
+ 
+    function uom(frm){
+    let dict=[];
+    if(cur_frm.doc.item_group =="Compound Walls" || cur_frm.doc.item_group =="Pavers"){
+        if (cur_frm.doc.stock_uom == "Nos"){
+                dict.push({
+                    "uom": "Nos",
+                    "conversion_factor": "1"
+                })
+
+                if (cur_frm.doc.pavers_per_sqft){
+                    dict.push({
+                        "uom": "Square Foot",
+                        "conversion_factor": cur_frm.doc.pavers_per_sqft
+                    })
+
+
+                }
+
+                if (cur_frm.doc.pavers_per_bundle){
+                    dict.push({
+                        "uom": "bundle",
+                        "conversion_factor": cur_frm.doc.pavers_per_bundle
+                    })
+
+
+                }
+                cur_frm.set_value("uoms",dict)
+                refresh_field('uoms')
+            }
+        }
+    }

--- a/ganapathy_pavers/hooks.py
+++ b/ganapathy_pavers/hooks.py
@@ -68,7 +68,8 @@ after_install = ["ganapathy_pavers.custom.py.item_group.item_group",
 				 "ganapathy_pavers.utils.py.vehicle_log.batch_customization",
 				 "ganapathy_pavers.utils.py.assets.item_customization",
 				 "ganapathy_pavers.utils.py.worstation.item_customization",
-				 "ganapathy_pavers.utils.py.purchase_order.batch_customization"
+				 "ganapathy_pavers.utils.py.purchase_order.batch_customization",
+				 "ganapathy_pavers.utils.py.item.batch_customization"
 				 ]
 				
 
@@ -194,7 +195,8 @@ after_migrate=["ganapathy_pavers.custom.py.site_work.create_status",
               "ganapathy_pavers.custom.py.property_setter.property_setter",
 			  "ganapathy_pavers.utils.py.vehicle.batch_customization",
 			  "ganapathy_pavers.utils.py.maintenance_details.batch_customization",
-			  "ganapathy_pavers.utils.py.vehicle_log.batch_customization"]
+			  "ganapathy_pavers.utils.py.vehicle_log.batch_customization",
+			  "ganapathy_pavers.utils.py.item.batch_customization"]
 
 
 doctype_js = {

--- a/ganapathy_pavers/utils/py/item.py
+++ b/ganapathy_pavers/utils/py/item.py
@@ -1,0 +1,16 @@
+from frappe.custom.doctype.property_setter.property_setter import make_property_setter
+def batch_customization():
+    batch_property_setter()
+def batch_property_setter():                
+    make_property_setter("Item", "serial_nos_and_batches", "depends_on", "eval:doc.item_group == 'Raw Material'", "Data")
+    make_property_setter("Item", "reorder_section", "depends_on", "eval:doc.item_group == 'Pavers' && doc.item_group == 'Compound Walls'", "Data")
+    make_property_setter("Item", "section_break_11", "depends_on", "eval:doc.item_group == 'Compound Walls'", "Data")
+    make_property_setter("Item", "opening_stock", "depends_on", "eval:doc.item_group == 'Compound Walls'", "Data")
+    make_property_setter("Item", "valuation_rate", "depends_on", "eval:doc.item_group == 'Compound Walls'", "Data")
+    make_property_setter("Item", "standard_rate", "depends_on", "eval:doc.item_group == 'Compound Walls'", "Data")
+    make_property_setter("Item", "is_fixed_asset", "depends_on", "eval:doc.item_group == 'Compound Walls'", "Data")
+    make_property_setter("Item", "per_rack", "depends_on", "eval:doc.item_group == 'Compound Walls'", "Data")
+    make_property_setter("Item", "per_plate", "depends_on", "eval:doc.item_group == 'Compound Walls'", "Data")
+    make_property_setter("Item", "pavers_per_layer", "depends_on", "eval:doc.item_group == 'Compound Walls'", "Data")
+    make_property_setter("Item", "no_of_layers_per_bundle", "depends_on", "eval:doc.item_group == 'Compound Walls'", "Data")
+    make_property_setter("Item", "stock_uom", "default", "Nos", "Data")


### PR DESCRIPTION
This PR contains:

- Code that helps in automatically fills UOM table and reduces the burden of manual work.
- Item field customizations (Done in python):

**Depends on done for the following:**

- serial_nos_and_batches
- reorder_section
- section_break_11
- opening_stock
- valuation_rate
- standard_rate
- is_fixed_asset
- per_rack
- per_plate
- pavers_per_layer
- no_of_layers_per_bundle
- stock_uom


**Screenshots:**

Table that gets filled in automatically:
![Screenshot from 2022-07-26 16-49-38](https://user-images.githubusercontent.com/95607390/180994190-82e158f7-f646-4362-9553-735929f00980.png)